### PR TITLE
Fixed typo in View.setWithDocs

### DIFF
--- a/src/java/com/fourspaces/couchdb/View.java
+++ b/src/java/com/fourspaces/couchdb/View.java
@@ -191,7 +191,7 @@ public class View {
 	}
 
     public void setWithDocs(Boolean withDocs) {
-		this.includeDocs = includeDocs;
+		this.includeDocs = withDocs;
 	}
 	
 	/**


### PR DESCRIPTION
The method wasn't working - it was ignoring the passed in Boolean.
